### PR TITLE
light themeでコードブロックの行番号が見えるようにした

### DIFF
--- a/docs/.vitepress/theme/tailwind.css
+++ b/docs/.vitepress/theme/tailwind.css
@@ -19,7 +19,7 @@
     --vp-c-base-darker: #003d71;
     --vp-c-text-light-1: theme(colors.light-text-primary);
     --vp-c-text-light-2: theme(colors.light-text-primary/75%);
-    --vp-c-text-light-3: theme(colors.light-back-primary/33%);
+    --vp-c-text-light-3: theme(colors.light-text-primary/33%);
     --vp-c-text-dark-1: theme(colors.dark-text-primary/86%);
     --vp-c-text-dark-2: theme(colors.dark-text-primary/60%);
     --vp-c-text-dark-3: theme(colors.dark-text-primary/38%);


### PR DESCRIPTION
## before
![image](https://github.com/pikachu0310/traP-isucon-workshop/assets/50443000/c76be63d-f6f6-44fa-9675-f32b589634c9)


## after
![image](https://github.com/pikachu0310/traP-isucon-workshop/assets/50443000/8e63460d-6f54-4bf4-8e2e-361c8e7e20a6)
